### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group = com.enonic.app
 projectName = licensemanager
 appName = com.enonic.app.licensemanager
 xpVersion=8.0.0-B4
-version=2.1.1-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump master version `2.1.1-SNAPSHOT` → `3.0.0-SNAPSHOT` (next major, XP 8 line).
- Configure `enonic-gradle.yml` so CI classifies pushes to both `master` and `2.x` as release-branch builds.
- The `2.x` maintenance branch (XP 7 line) is created from the post-`v2.1.0` SNAPSHOT commit `de2de73`. A separate PR against `2.x` adds the same `releaseBranch` config there (required because the release tooling reads the workflow file from the branch being pushed).

## Test plan

- [ ] CI build on this branch is green (`./gradlew clean build`).
- [ ] After merge, master CI run picks up the new version.