### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block (listing `master` and `2.x`) to `.github/workflows/enonic-gradle.yml` on the `2.x` maintenance branch.
- Required so pushes to `2.x` are classified as release-branch builds — the release tooling reads `releaseBranch` from the workflow file on the branch being built. Companion to the master-side bump in #51.
- No version bump and no other changes here; this matches app-booster's pattern for the maintenance branch.

## Test plan

- [ ] CI on this PR builds the existing `2.1.1-SNAPSHOT` artifact green.
- [ ] After merge, a push to `2.x` is recognized as a release branch by `enonic/release-tools/build-and-publish@master`.