### PR TITLE
Migrate to lib-asset #54

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     //──────────────────────────────────────────────────────────────────────────
     // Other enonic libs (com.enonic.lib)
     //──────────────────────────────────────────────────────────────────────────
+    include libs.lib.asset
     include libs.lib.mustache
 
     // Used as /lib/license in many services

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
+lib-asset = "2.0.0-SNAPSHOT"
 lib-mustache = "2.1.1"
 lib-license = "4.0.0-SNAPSHOT"
 
 [libraries]
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "lib-asset" }
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "lib-mustache" }
 lib-license = { module = "com.enonic.lib:lib-license", version.ref = "lib-license" }

--- a/src/main/resources/admin/tools/licenses/licenses.js
+++ b/src/main/resources/admin/tools/licenses/licenses.js
@@ -1,8 +1,9 @@
 const mustacheLib = require('/lib/mustache');
 const portalLib = require('/lib/xp/portal');
 const adminLib = require('/lib/xp/admin');
+const assetLib = require('/lib/enonic/asset');
 
-const assetUrl = portalLib.assetUrl;
+const assetUrl = assetLib.assetUrl;
 const render = mustacheLib.render;
 const serviceUrl = portalLib.serviceUrl;
 

--- a/src/main/resources/admin/tools/licenses/licenses.yaml
+++ b/src/main/resources/admin/tools/licenses/licenses.yaml
@@ -6,3 +6,4 @@ allow:
   - "role:com.enonic.app.licensemanager"
 apis:
   - "admin:extension"
+  - "asset"


### PR DESCRIPTION
## Summary

- Swap `portal.assetUrl` (deprecated in lib-portal) for `lib-asset.assetUrl` in the admin tool `admin/tools/licenses/licenses.js`.
- Add `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT` (via `libs.versions.toml`) to `build.gradle`.
- Whitelist the `asset` API on `admin/tools/licenses/licenses.yaml` (`apis: ["admin:extension", "asset"]`) so the bundled asset endpoint is mounted in the admin tool context.

The call still uses the empty-path idiom (`assetUrl({path: ''})`) — same pattern as `app-applications`'s admin tool. The template's `{{assetsUri}}/foo` concatenation continues to work because lib-asset's base URL ends without a trailing slash.

Closes #54

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean
- [x] E2E against `xp-distro` 8.0.0-SNAPSHOT inside `claude-dev`: bundle reaches ACTIVE
- [x] Admin tool HTML at `/admin/com.enonic.app.licensemanager/licenses` returns HTTP 200
- [x] Asset URLs render as `/admin/.../_/<app>:asset/<fingerprint>/...`
- [x] Spot-checked 8 asset URLs (favicon.svg, bulma.css, main.css, jquery, clipboard, datepicker, fontawesome, main.js) — all HTTP 200