### PR TITLE
Handle missing license issue date #13

### DIFF
--- a/src/main/resources/services/downloadLicense/downloadLicense.js
+++ b/src/main/resources/services/downloadLicense/downloadLicense.js
@@ -13,8 +13,18 @@ exports.get = function (req) {
     var app = storeLib.getApplicationByLicenseId(req.params.id);
 
     var body = license.license;
-    var fileName = storeLib.prettifyName(license.issuedTo) + '-' + storeLib.prettifyName(app.displayName) + '-' +
-                   license.issueTime.substring(0, 10) + '.lic';
+
+    var parts = [];
+    if (license.issuedTo) {
+        parts.push(storeLib.prettifyName(license.issuedTo));
+    }
+    if (app && app.displayName) {
+        parts.push(storeLib.prettifyName(app.displayName));
+    }
+    if (license.issueTime) {
+        parts.push(license.issueTime.substring(0, 10));
+    }
+    var fileName = (parts.length ? parts.join('-') : 'license') + '.lic';
 
     return {
         contentType: 'text/plain',


### PR DESCRIPTION
## Summary

Fix `TypeError: Cannot read property "substring" from undefined` when downloading a license that has no `issueTime`.

`createLicense`'s `parseDate` returns `null` for empty or unparseable input, so a license can legitimately be stored without an `issueTime`. `downloadLicense` assumed it was always present and blew up on `license.issueTime.substring(0, 10)`.

The handler now builds the filename from whichever of `issuedTo`, `app.displayName`, and `issueTime` are present — joined by `-` — so the download always produces a valid `.lic` filename. If none are present (extreme edge case), the file is named `license.lic`.

### Before / after

| `issuedTo` | `issueTime` | app.displayName | Before | After |
|---|---|---|---|---|
| `Acme Inc` | `2026-05-10T…` | `My App` | `acme-inc-my-app-2026-05-10.lic` | `acme-inc-my-app-2026-05-10.lic` (unchanged) |
| `Acme Inc` | *(missing)*    | `My App` | 500 `TypeError`                  | `acme-inc-my-app.lic` |
| *(missing)*| *(missing)*    | `My App` | 500 `TypeError`                  | `my-app.lic` |

Closes #13

## Test plan

- [x] `./gradlew build` green (no Java/JS test harness in this repo)
- [ ] Manual: download a license created with an empty issue date and confirm the download succeeds with a sensible filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)